### PR TITLE
Add link to ChiantiPy slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ bit.ly/sprints2017
     - Scott Sievert
     - https://speakerdeck.com/stsievert/scipy-2017-next
 - ChiantiPy
-    - https://github.com/wtbarnes/chiantipy-talk-scipy-2017
+    - Source: https://github.com/wtbarnes/chiantipy-talk-scipy-2017
+    - Slides: https://wtbarnes.github.io/chiantipy-talk-scipy-2017/
 
 - python packaging
     - https://github.com/python-packaging-tutorial/python-packaging-tutorial


### PR DESCRIPTION
The previous link was just to the notebooks and source used to make the talk. Added a link to the slides hosted on GitHub pages.